### PR TITLE
feat: 매장 목록 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.security:spring-security-crypto'
 //    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/com/zerobase/mytabling/cache/service/RedisService.java
+++ b/src/main/java/com/zerobase/mytabling/cache/service/RedisService.java
@@ -1,0 +1,97 @@
+package com.zerobase.mytabling.cache.service;
+
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RedisService {
+
+  private final RedisTemplate<String, Object> redisTemplate;
+
+  /**
+   * 매장 별점 저장
+   */
+  public void saveRating(Long storeId, double rating) {
+    redisTemplate.opsForZSet().add("store_ratings", String.valueOf(storeId), rating);
+  }
+
+  /**
+   * 매장 별점 조회
+   */
+  public Double getRating(Long storeId) {
+    return redisTemplate.opsForZSet().score("store_ratings", String.valueOf(storeId));
+  }
+
+  /**
+   * 매장 ID 에 대한 모든 리뷰 개수 저장
+   */
+  public void saveTotalReviewsCount(Long storeId, long totalReviews) {
+    redisTemplate.opsForHash()
+        .put("store_total_reviews", String.valueOf(storeId), String.valueOf(totalReviews));
+  }
+
+  /**
+   * 매장 ID 에 대한 모든 리뷰 개수 조회
+   */
+  public long getTotalReviewsCount(Long storeId) {
+//    Long totalReviews = (Long) redisTemplate.opsForHash().get("store_total_reviews", storeId);
+//    return totalReviews != null ? totalReviews : 0;
+    String totalReviewsStr = (String) redisTemplate.opsForHash()
+        .get("store_total_reviews", storeId.toString());
+    return totalReviewsStr != null ? Long.parseLong(totalReviewsStr) : 0;
+  }
+
+  /**
+   * 평균별점 내림차순 조회
+   */
+  public Set<String> getSortedStoreIdsDesc() {
+    return Objects.requireNonNull(redisTemplate.opsForZSet().reverseRange("store_ratings", 0, -1))
+        .stream()
+        .map(Object::toString)
+        .collect(Collectors.toCollection(LinkedHashSet::new));
+  }
+
+  /**
+   * 매장 평균 별점 조회
+   */
+  public Set<String> getSortedStoreIds(boolean ascending) {
+    if (ascending) {  // 오름차순
+      return Objects.requireNonNull(redisTemplate.opsForZSet().range("store_ratings", 0, -1))
+          .stream()
+          .map(Object::toString)
+          .collect(Collectors.toCollection(LinkedHashSet::new));
+    } else {          // 내림차순
+      return Objects.requireNonNull(redisTemplate.opsForZSet().reverseRange("store_ratings", 0, -1))
+          .stream()
+          .map(Object::toString)
+          .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+  }
+
+  /*
+  public Double getAverageRating(Long storeId) {
+    return redisTemplate.opsForZSet().score("store_ratings", storeId);
+  }
+
+  public Set<Object> getTopRatedStores(int count) {
+    return redisTemplate.opsForZSet().reverseRange("store_ratings", 0, count - 1);
+  }
+
+  private String getRatingKey(Long storeId) {
+    return "store_rating:" + storeId;
+  }
+
+  private String getTotalReviewsKey(Long storeId) {
+    return "store_total_reviews:" + storeId;
+  }
+   */
+
+}

--- a/src/main/java/com/zerobase/mytabling/config/CacheConfig.java
+++ b/src/main/java/com/zerobase/mytabling/config/CacheConfig.java
@@ -1,0 +1,67 @@
+package com.zerobase.mytabling.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@Slf4j
+public class CacheConfig {
+
+  @Value("${spring.data.redis.host}")
+  private String host;
+
+  @Value("${spring.data.redis.port}")
+  private int port;
+
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate(
+      RedisConnectionFactory redisConnectionFactory) {
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setConnectionFactory(redisConnectionFactory);
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+    redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+    redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+//    redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
+    return redisTemplate;
+  }
+
+  @Bean
+  public CacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
+
+    // redis key, value 직렬화 지정
+    RedisCacheConfiguration conf = RedisCacheConfiguration.defaultCacheConfig()
+        .serializeKeysWith(
+            RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+        .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
+            new GenericJackson2JsonRedisSerializer()));
+
+    return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory)
+        .cacheDefaults(conf)
+        .build();
+  }
+
+  /**
+   * redis 커넥션
+   */
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    RedisStandaloneConfiguration conf = new RedisStandaloneConfiguration();
+    conf.setHostName(this.host);
+    conf.setPort(this.port);
+    return new LettuceConnectionFactory(conf);
+  }
+
+}

--- a/src/main/java/com/zerobase/mytabling/store/controller/StoreController.java
+++ b/src/main/java/com/zerobase/mytabling/store/controller/StoreController.java
@@ -1,12 +1,15 @@
 package com.zerobase.mytabling.store.controller;
 
+import com.zerobase.mytabling.store.domain.Store;
 import com.zerobase.mytabling.store.dto.StoreDto;
 import com.zerobase.mytabling.store.service.StoreService;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,4 +31,21 @@ public class StoreController {
         .body("Store registered successfully , id = " + savedId);
   }
 
+  /**
+   * 매장 목록 조회 - 오름차순
+   */
+  @GetMapping("/stores/asc")
+  public ResponseEntity<List<Store>> getStoresAsc() {
+    List<Store> stores = storeService.getStoresSortedByRating(true);
+    return ResponseEntity.ok(stores);
+  }
+
+  /**
+   * 매장 목록 조회 - 내림차순
+   */
+  @GetMapping("/stores/desc")
+  public ResponseEntity<List<Store>> getStoresDesc() {
+    List<Store> stores = storeService.getStoresSortedByRating(false);
+    return ResponseEntity.ok(stores);
+  }
 }

--- a/src/main/java/com/zerobase/mytabling/store/repository/StoreRepository.java
+++ b/src/main/java/com/zerobase/mytabling/store/repository/StoreRepository.java
@@ -1,8 +1,12 @@
 package com.zerobase.mytabling.store.repository;
 
 import com.zerobase.mytabling.store.domain.Store;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
 
+  List<Store> findAllByIdInOrderById(List<Long> ids);
+  List<Store> findAllByIdIn(List<Long> ids);
 }

--- a/src/main/java/com/zerobase/mytabling/store/service/StoreService.java
+++ b/src/main/java/com/zerobase/mytabling/store/service/StoreService.java
@@ -1,9 +1,14 @@
 package com.zerobase.mytabling.store.service;
 
+import com.zerobase.mytabling.cache.service.RedisService;
 import com.zerobase.mytabling.store.domain.Store;
 import com.zerobase.mytabling.store.dto.StoreDto;
 import com.zerobase.mytabling.store.repository.StoreRepository;
-import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -14,6 +19,7 @@ import org.springframework.stereotype.Service;
 public class StoreService {
 
   private final StoreRepository storeRepository;
+  private final RedisService redisService;
 //  private final ManagerRepository managerRepository;
 
   /**
@@ -31,6 +37,31 @@ public class StoreService {
       log.error("Failed to register store", e);
       throw e;
     }
+  }
+
+  /**
+   * 별점 높은순, 낮은 순 매장 검색
+   */
+  public List<Store> getStoresSortedByRating(boolean ascending) {
+
+    // 평균 별점 오름차순,내림차순에 따라 매장 id 가져오기
+    Set<String> storeIds = redisService.getSortedStoreIds(ascending);
+    log.info("sorted store ids : {}", storeIds);
+
+    // 매장 ID Long으로 변환
+    List<Long> storeIdsAsLong = storeIds.stream()
+        .map(Long::valueOf)
+        .collect(Collectors.toList());
+
+    log.info("store id convert string to Long : {}", storeIdsAsLong);
+
+    List<Store> stores = storeRepository.findAllByIdIn(storeIdsAsLong);
+    List<Long> storeIdsFromStores = stores.stream()
+        .map(Store::getId)
+        .collect(Collectors.toList());
+    log.info("repository find store IDs: {}", storeIdsFromStores);
+
+    return storeRepository.findAllByIdIn(storeIdsAsLong);
   }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,9 +9,14 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:
         format_sql: true
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
 

--- a/src/test/http/store.http
+++ b/src/test/http/store.http
@@ -4,7 +4,7 @@ Content-Type: application/json
 
 {
   "storeName": "매장1",
-  "storeTelNumber": "010-1234-567",
+  "storeTelNumber": "010-1234-5678",
   "openTime": "09:00",
   "closeTime": "21:00",
   "reservationTimeUnit": 90,
@@ -13,3 +13,7 @@ Content-Type: application/json
   "city": "서울",
   "postalCode": "12345"
 }
+
+### 매장 조회
+GET http://localhost:8080/stores/desc
+Accept: application/json


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 매장 목록 기능이 구현되지 않았습니다.

**TO-BE**

1. 리뷰 작성:
    - 새로운 리뷰가 작성되면:
        - 해당 매장의 기존 별점 데이터와 신규 리뷰의 별점을 이용하여 새로운 평균 별점을 계산합니다.
        - Redis의 sorted set을 이용해 평균 별점 데이터를 새로운 평균 별점으로 업데이트합니다.
        
2. 정렬 및 표시:
    -  Redis에서 별점순으로 정렬된 매장 ID들을 가져옵니다.
        - Redis에서 'ZREVRANGE' 명령을 사용하면 별점 내림차순으로 매장 ID를 검색할 수 있습니다.
        - redisService.java의 getSortedStoreIds(boolean ascending) true : 오름차순, getSortedStoreIds(false) : 내림차순
    - 별점에 따라 정렬된 매장 데이터를 표시합니다.
    
    
    redis의 sorted set으로 매장별 평균 별점을 저장하고, 별점의 오름차순/내림차순 정렬 - 정상작동
    service단에서 평균 별점의 오름차순/내림차순 매장 id 조회 - 정상작동
    **List<매장id>를 repository에서 파라미터로 전달해 조회 시 결과 : 매장 id 1 , 2, 3, ... 으로 재정렬되서 조회 됨 - 비정상 작동**
    
    
    
    
    
    
    
    아래는 storeService.java의 getStoresSortedByRating 메서드 입니다.

`

  
    public List<Store> getStoresSortedByRating(boolean ascending) {
      // 평균 별점 오름차순,내림차순에 따라 매장 id 가져오기
    Set<String> storeIds = redisService.getSortedStoreIds(ascending);
    log.info("sorted store ids : {}", storeIds);
    // 평균 별점에 맞게 "2", "1", "3" 반환

    // 매장 ID Long으로 변환
    List<Long> storeIdsAsLong = storeIds.stream()
        .map(Long::valueOf)
        .collect(Collectors.toList());

    log.info("store id convert string to Long : {}", storeIdsAsLong);
    // Long으로 변환해 정상적으로 2, 1, 3 반환

    List<Store> stores = storeRepository.findAllByIdIn(storeIdsAsLong);
    List<Long> storeIdsFromStores = stores.stream()
        .map(Store::getId)
        .collect(Collectors.toList());
    log.info("repository find store IDs: {}", storeIdsFromStores);
    // (!!!!!!!!!!!) 1, 2, 3으로 재정렬 되는 문제 

    return storeRepository.findAllByIdIn(storeIdsAsLong);
  }
`

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 